### PR TITLE
correct script name in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install -r requirements.txt
 ## Using the Script
 
 ```bash
-usage: python add_metadata_CCAM_temp.py
+usage: python add_metadata_CCAM_AirTemp.py
 ```
 Creates updated NetCDF file from CSIRO with added metadata.
 ```


### PR DESCRIPTION
I realised the name of the script file to call as instructed in the usage section was not matching with the filename. This PR just corrects it. This does not affect the result of running the script or anything else. It is just a correction in the README file.